### PR TITLE
 Separate headers page added to avoid future code repetition

### DIFF
--- a/Tests/Layout/SiteHeader.cs
+++ b/Tests/Layout/SiteHeader.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Playwright;
+
+namespace buk_klab_Tests.Tests.Layout
+{
+    public class SiteHeader
+    {
+        private readonly IPage _page;
+
+        // Header locators
+        private readonly ILocator _bookKlabTitle;
+        private readonly ILocator _booksInHeader;
+        private readonly ILocator _membersInHeader;
+        private readonly ILocator _aboutInHeader;
+        private readonly ILocator _signInInInHeader;
+        private readonly ILocator _joinBookKlabButtonInHeader;
+
+        public SiteHeader(IPage page)
+        {
+            _page = page ?? throw new ArgumentNullException(nameof(page));
+
+            _bookKlabTitle = _page.Locator("section:has-text('buk klab') a");
+            _booksInHeader = _page.Locator("a:has-text('books')");
+            _membersInHeader = _page.Locator("a:has-text('members')");
+            _aboutInHeader = _page.Locator("a:has-text('about')");
+            _signInInInHeader = _page.Locator("a:has-text('sign in')");
+            _joinBookKlabButtonInHeader = _page.Locator("ul li a:has-text('join buk klab')");
+        }
+
+        public async Task<bool> AreHeaderElemnentsVisible()
+        {
+            var locators = new List<ILocator>
+            {
+                _bookKlabTitle,
+                _booksInHeader,
+                _membersInHeader,
+                _aboutInHeader,
+                _signInInInHeader,
+                _joinBookKlabButtonInHeader
+            };
+
+            foreach (var locator in locators)
+            {
+                if (!await locator.IsVisibleAsync())
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public async Task ClickBooks() => await _booksInHeader.ClickAsync();
+        public async Task ClickMembers() => await _membersInHeader.ClickAsync();
+        public async Task ClickAbout() => await _aboutInHeader.ClickAsync();
+        public async Task ClickSignIn() => await _signInInInHeader.ClickAsync();
+        public async Task ClickJoin() => await _joinBookKlabButtonInHeader.ClickAsync();
+    }
+}

--- a/Tests/Pages/HomePage.cs
+++ b/Tests/Pages/HomePage.cs
@@ -4,47 +4,32 @@ namespace buk_klab_Tests.Tests.Pages;
 public class HomePage
 {
     private IPage _page;
+    private Layout.SiteHeader _header;
 
-    private readonly ILocator _bookKlabTitle;
-    private readonly ILocator _booksInHeader;
-    private readonly ILocator _membersInHeader;
-    private readonly ILocator _aboutInHeader;
-    private readonly ILocator _signInInInHeader;
-    private readonly ILocator _joinBookKlabButtonInHeader;
     private readonly ILocator _joinBookKlabButtonInBody;
     private readonly ILocator _textInMainBody;
     private readonly ILocator _howDoesItWork;
     private readonly ILocator _currentReading;
 
-    public HomePage(IPage page)
+    public HomePage(IPage page, Layout.SiteHeader header)
     {
         _page = page;
+        _header = header;
 
         //Element locators
-        _bookKlabTitle = page.Locator("section:has-text('buk klab') a");
-        _booksInHeader = page.Locator("a:has-text('books')");
-        _membersInHeader = page.Locator("a:has-text('members')");
-        _aboutInHeader = page.Locator("a:has-text('about')");
-        _signInInInHeader = page.Locator("a:has-text('sign in')");
-        _joinBookKlabButtonInHeader = page.Locator("ul li a:has-text('join buk klab')");
         _joinBookKlabButtonInBody = page.Locator("section:has-text('Welcome tobuk klabbuk klab is')").Locator("a");
         _textInMainBody = page.Locator("section:has-text('Welcome tobuk klabbuk klab is')");
         _howDoesItWork = page.Locator("section:has-text('how does it work?')");
         _currentReading = page.Locator("section:has-text('what are we currently reading?')");
     }
 
-    public async Task ClickJoinBookKlab() => await _joinBookKlabButtonInHeader.ClickAsync();
+    public async Task ClickJoinBookKlab() => await _joinBookKlabButtonInBody.ClickAsync();
+    public Layout.SiteHeader SiteHeader => _header;
 
-    public async Task<bool> AllElementsAreVisible()
+    public async Task<bool> AreHomePageElementsVisible()
     {
         var locators = new List<ILocator>
         {
-            _bookKlabTitle,
-            _booksInHeader,
-            _membersInHeader,
-            _aboutInHeader,
-            _signInInInHeader,
-            _joinBookKlabButtonInHeader,
             _joinBookKlabButtonInBody,
             _textInMainBody,
             _howDoesItWork,
@@ -58,7 +43,6 @@ public class HomePage
                 return false;
             }
         }
-
         return true;
     }
 

--- a/Tests/Scenarios/HomePageTests.cs
+++ b/Tests/Scenarios/HomePageTests.cs
@@ -1,3 +1,4 @@
+using buk_klab_Tests.Tests.Layout;
 using buk_klab_Tests.Tests.Pages;
 
 namespace buk_klab_Tests.Pages;
@@ -7,9 +8,11 @@ public class HomePageTests : BasePage
     [Test]
     public async Task AllElementsLoadedOnHomePage()
     {
-        HomePage homePage = new HomePage(page);
-        var elemtsExists = await homePage.AllElementsAreVisible();
-        Assert.IsTrue(elemtsExists);
-        await homePage.ClickJoinBookKlab();
+        HomePage homePage = new HomePage(page, new SiteHeader(page));
+
+        Assert.IsTrue(await homePage.SiteHeader.AreHeaderElemnentsVisible(), "Header elements are not visible.");
+        Assert.IsTrue(await homePage.AreHomePageElementsVisible(), "Header elements are not visible.");
+
+        await homePage.SiteHeader.ClickBooks();
     }
 }

--- a/Tests/Scenarios/HomePageTests.cs
+++ b/Tests/Scenarios/HomePageTests.cs
@@ -11,7 +11,7 @@ public class HomePageTests : BasePage
         HomePage homePage = new HomePage(page, new SiteHeader(page));
 
         Assert.IsTrue(await homePage.SiteHeader.AreHeaderElemnentsVisible(), "Header elements are not visible.");
-        Assert.IsTrue(await homePage.AreHomePageElementsVisible(), "Header elements are not visible.");
+        Assert.IsTrue(await homePage.AreHomePageElementsVisible(), "HomePage elements are not visible.");
 
         await homePage.SiteHeader.ClickBooks();
     }

--- a/Tests/Utilities/BasePage.cs
+++ b/Tests/Utilities/BasePage.cs
@@ -1,4 +1,5 @@
-﻿using buk_klab_Tests.Tests.Pages;
+﻿using buk_klab_Tests.Tests.Layout;
+using buk_klab_Tests.Tests.Pages;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Playwright;
@@ -13,6 +14,7 @@ public class BasePage
     protected HomePage _homePage;
     protected MembersPage _membersPage;
     protected SignInPage _signinPage;
+    protected SiteHeader _header;
 
     [SetUp]
     public async Task Setup()
@@ -29,6 +31,7 @@ public class BasePage
             _homePage = ActivatorUtilities.CreateInstance<HomePage>(_serviceProvider, page);
             _membersPage = ActivatorUtilities.CreateInstance<MembersPage>(_serviceProvider, page);
             _signinPage = ActivatorUtilities.CreateInstance<SignInPage>(_serviceProvider, page);
+            _header = ActivatorUtilities.CreateInstance<SiteHeader>(_serviceProvider, page);
 
             await NavigateToHomePageUrlAsync(page);
         }
@@ -38,7 +41,7 @@ public class BasePage
             throw;
         }
     }
-
+        
     [TearDown]
     public async Task Teardown()
     {

--- a/Tests/Utilities/BasePage.cs
+++ b/Tests/Utilities/BasePage.cs
@@ -24,8 +24,8 @@ public class BasePage
             _serviceProvider = DependencyContainer.BuildServiceProvider();
 
             _browser = await _serviceProvider.GetRequiredService<Task<IBrowser>>();
-            page = await _browser.NewPageAsync();
-           
+            page = _serviceProvider.GetRequiredService<IPage>();
+
             _aboutPage = ActivatorUtilities.CreateInstance<AboutPage>(_serviceProvider, page);
             _booksPage = ActivatorUtilities.CreateInstance<BooksPage>(_serviceProvider, page);
             _homePage = ActivatorUtilities.CreateInstance<HomePage>(_serviceProvider, page);


### PR DESCRIPTION
Elements that are repeating in header on all tabs such as "[books], [members], [about][sign in] moved to separate headers page to avoid future code repetition.